### PR TITLE
Adds script to compress the SVG files

### DIFF
--- a/.github/workflows/nodejs-cli.yml
+++ b/.github/workflows/nodejs-cli.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - 'main'
+      - 'workflows/**'
   pull_request:
     branches:
       - 'main'
+      - 'workflows/**'
 
 jobs:
   test:

--- a/.github/workflows/nodejs-cli.yml
+++ b/.github/workflows/nodejs-cli.yml
@@ -49,3 +49,4 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build --if-present
+      - run: npm run build:release --if-present

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# build icons directory
+icons
+
 # Logs
 logs
 *.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Hi! Thanks for the interest in contributing 🤗
   - [Development](#development)
     - [Dependencies](#dependencies)
     - [Build system](#build-system)
+      - [Release build](#release-build)
     - [Testing](#testing)
     - [Schemas](#schemas)
     - [SVG designs](#svg-designs)
@@ -61,9 +62,13 @@ Saga Icons uses [Node.js](https://nodejs.org/en/about/) to generate icons, so if
   <img alt="Saga Icons Build system" src="docs/assets/build-system-diagram.webp">
 </div>
 
-The build system should be able to asynchronously generate multiple customizable [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) files from one simple [JSON](src/schemas/solid.json) file.
+The build system should be able to asynchronously generate multiple customizable [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) files from one simple [JSON schema](src/schemas/solid.json) file.
 
 You are welcome to contribute to the improvement of this process by fixing bugs, improving performance, typos, documentation, or workflow.
+
+#### Release build
+
+The build system also prepares the generated SVG files for the release files in Github by compressing them into a single zip file using the [adm-zip](https://github.com/cthackers/adm-zip) library.
 
 ### Testing
 
@@ -96,13 +101,13 @@ To add icons at the `src/schemas`, you should follow the format bellow:
 }
 ```
 
-The example above, using the build script, would generate something like (`dist/solid/mock-empty-example-24x24.svg`):
+The example above, using the build script, would generate something like (`icons/solid/web/mock-empty-example-24x24.svg`):
 
 ```svg
 <svg viewBox="0 0 24 24" width="24" height="24"><g><path d="C 1.111 Z"/></g></svg>
 ```
 
-The [d (drawn)](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d) attribute is the only thing from the [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) icons that are stored inside the [schema](src/schemas/solid.json).
+The [d (drawn)](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d) attribute is the only thing from the designed [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) icons that are stored inside the [JSON schema](src/schemas/solid.json).
 
 This allows us to maintain a clean [schema](src/schemas/solid.json) file whilst easily customizing and generating hundreds of [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) files.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "adm-zip": "^0.5.10",
         "yargs": "^17.6.2"
       },
       "devDependencies": {
@@ -1298,6 +1299,14 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/ajv": {
@@ -5295,6 +5304,11 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint --exit-on-fatal-error --color --ext .js --fix .",
-    "build": "node ./src/index.js -o ./icons",
+    "build": "node ./src/index.js",
+    "build:release": "node ./src/index.js --compress --outDir ./dist",
     "test": "jest",
     "test:lint": "eslint . --format unix --max-warnings 1",
     "test:format": "prettier --check ."
@@ -30,6 +31,7 @@
     "prettier": "^2.8.2"
   },
   "dependencies": {
+    "adm-zip": "^0.5.10",
     "yargs": "^17.6.2"
   }
 }

--- a/src/createSVG.js
+++ b/src/createSVG.js
@@ -5,7 +5,7 @@ const vectorize = require('./vectorize')
  *
  * @param {object} variantSchema the icon variant schema.
  * @param {{xml: boolean}} buildOptions the createSVG options to control XML compatibility.
- * @return {Promise<{variant: string, icons: any[]}>} returns the variant name and all the SVG icons.
+ * @return {Promise<{variant: string, type: string, icons: any[]}>} returns the variant name and all the SVG icons.
  */
 async function createSVG(variantSchema, buildOptions = { xml: false }) {
   const xml = buildOptions.xml ? true : false
@@ -15,7 +15,8 @@ async function createSVG(variantSchema, buildOptions = { xml: false }) {
    */
   const size = 24
 
-  const variant = `${variantSchema.name}/${xml ? 'xml' : 'web'}-icons`
+  const variant = variantSchema.name
+  const type = xml ? 'xml' : 'web'
   const schemas = Object.keys(variantSchema.icons)
 
   const XMLSchema = !xml ? undefined : require('./schemas/XML.json')
@@ -54,7 +55,7 @@ async function createSVG(variantSchema, buildOptions = { xml: false }) {
     })
   )
 
-  return { variant, icons: vectors }
+  return { variant, type, icons: vectors }
 }
 
 module.exports = createSVG

--- a/src/exportFiles.js
+++ b/src/exportFiles.js
@@ -1,27 +1,53 @@
+const AdmZip = require('adm-zip')
 const fs = require('fs').promises
 const path = require('path')
 
 /**
- * Asynchronously export multiple SVG files inside the `dist` folder.
+ * Asynchronously export multiple SVG files.
  *
  * @param {{variant: string, icons: any[]}} data the data returned by the `createSVG` module.
- * @param {string} to the path to export the files (Default: dist).
+ * @param {string} to the path to export the files (Default: 'icons').
+ * @param {boolean} compressData control if should compress the SVG files or not (Default: false).
  * @return {undefined} Fullfills with `undefined` on success.
  */
-async function exportFiles(data, to = 'dist') {
-  try {
-    const { variant, icons } = data
-    const outDir = path.resolve(__dirname, '../', to, variant)
+async function exportFiles(data, to = 'icons', compressData = false) {
+  const { variant, type, icons } = data
+  const outDir = path.resolve(__dirname, '../', to, variant, type)
 
+  try {
     await fs.mkdir(outDir, { recursive: true })
 
     await Promise.all(
       icons.map(async (icon) => {
         const outFile = path.resolve(outDir, `${icon.filename}.svg`)
 
-        return await fs.writeFile(outFile, icon.svg, { encoding: 'utf-8' })
+        try {
+          const fileData = new Uint8Array(Buffer.from(icon.svg))
+          return await fs.writeFile(outFile, fileData)
+        } catch (err) {
+          return Promise.reject(err)
+        }
       })
     )
+
+    if (!compressData) return undefined
+
+    const zip = new AdmZip()
+    const releaseFile = path.resolve(
+      __dirname,
+      '../',
+      to,
+      `${variant}-24x24.${type}-icons.zip`
+    )
+
+    zip.addLocalFolder(outDir)
+
+    await zip.writeZipPromise(releaseFile, { overwrite: true })
+
+    await fs.rm(path.resolve(__dirname, '../', to, variant), {
+      force: true,
+      recursive: true,
+    })
 
     return undefined
   } catch (error) {

--- a/src/exportFiles.js
+++ b/src/exportFiles.js
@@ -13,6 +13,8 @@ const path = require('path')
 async function exportFiles(data, to = 'icons', compressData = false) {
   const { variant, type, icons } = data
   const outDir = path.resolve(__dirname, '../', to, variant, type)
+  const licenseFile = path.resolve(__dirname, '../', 'LICENSE.txt')
+  const licenseOutFile = path.resolve(outDir, 'LICENSE.txt')
 
   try {
     await fs.mkdir(outDir, { recursive: true })
@@ -29,6 +31,8 @@ async function exportFiles(data, to = 'icons', compressData = false) {
         }
       })
     )
+
+    await fs.copyFile(licenseFile, licenseOutFile)
 
     if (!compressData) return undefined
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,8 @@ const solid = require('./schemas/solid.json')
 
 const argv = yargs(hideBin(process.argv)).argv
 const outDir = argv.o || argv.outDir
+const compress = argv.compress
 
 createSVG(solid, { xml: argv.xml })
-  .then((data) => exportFiles(data, outDir))
+  .then((data) => exportFiles(data, outDir, compress))
   .catch(() => process.exit(1))

--- a/tests/createSVG.test.js
+++ b/tests/createSVG.test.js
@@ -7,7 +7,8 @@ describe('createSVG', () => {
 
     expect(data).toHaveProperty('variant')
     expect(data).toHaveProperty('icons')
-    expect(data.variant).toBe('mock/web-icons')
+    expect(data.variant).toBe('mock')
+    expect(data.type).toBe('web')
     expect(data.icons).toHaveLength(schemas.mock.icons.length)
   })
 
@@ -27,7 +28,8 @@ describe('createSVG', () => {
 
     expect(data).toHaveProperty('variant')
     expect(data).toHaveProperty('icons')
-    expect(data.variant).toBe('mock/xml-icons')
+    expect(data.variant).toBe('mock')
+    expect(data.type).toBe('xml')
 
     const { svg, filename } = data.icons[0]
 


### PR DESCRIPTION
# Summary
 
Currently, the build systems don't include a way to generate the SVG files and compress them automatically before adding them to the Github release. This PR tries to fix that.

## Solution

Each Saga Icons variant can generate a zipped file containing all the SVG files and a copy of the [LICENSE](https://github.com/santosned/saga-icons/blob/main/LICENSE.txt) file.

Thanks to [adm-zip](https://github.com/cthackers/adm-zip), this process can be easily achieved by running `npm run build:release`.