### PR TITLE
Rewrite Saga Icons initial documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall
+- Focusing on what is best not just for us as individuals, but for the overall
   community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or advances of
+- The use of sexualized language or imagery, and sexual attention or advances of
   any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address,
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
   without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[santosned@proton.me](mailto:santosned@proton.me).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,145 +1,92 @@
-# How To Contribute
+# Contributing to Saga Icons
 
-Hi! Thanks for the interest in contributing 🤗
+Thank you for the interest in contributing 😊
 
-🎯 The goal here is to make everything as transparent and easy as possible.
+Any contribution you make will be published at [github.com/santosned/saga-icons](https://github.com/santosned/saga-icons)
 
-**Table of Contents:**
+Read our [Code of Conduct](CODE_OF_CONDUCT.md) to keep our community approachable and respectable.
 
-- [How To Contribute](#how-to-contribute)
-  - [License](#license)
-  - [Github](#github)
-    - [Reporting bugs](#reporting-bugs)
-    - [Requesting features](#requesting-features)
-    - [Requesting icons](#requesting-icons)
-  - [Development](#development)
-    - [Dependencies](#dependencies)
-    - [Build system](#build-system)
-      - [Release build](#release-build)
-    - [Testing](#testing)
-    - [Schemas](#schemas)
-    - [SVG designs](#svg-designs)
-      - [Adding to the repo](#adding-to-the-repo)
+> On Github use the table of contents button in the top left corner of this document to easily go to a certain section of this guide.
 
-## License
+## Newcomers guide
 
-🤝 By contributing, you agree that your contributions will be licensed under the [project license](LICENSE.txt).
+Welcome 🤗 see our [README](README.md) file to get an overview of the project. Here are some resources to help you get started with open source contributions:
 
-## Github
+- [Finding ways to contribute to open source on GitHub](https://docs.github.com/en/get-started/exploring-projects-on-github/finding-ways-to-contribute-to-open-source-on-github)
+- [Setting up Git](https://docs.github.com/en/get-started/quickstart/set-up-git)
+- [Github Flow](https://docs.github.com/en/get-started/quickstart/github-flow)
+- [Collaborating with Pull Requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests)
 
-The development is hosted at [Github](https://github.com/santosned/saga-icons), keeping track of issues, features, and more.
+## Getting started
 
-🌐 **all issues** should be **written in English**, with a **clear and concise description** of the issue.
+### Issues
 
-It's also recommended that you **search** for any **existing issues** related to your problem before creating a new one.
+Please don't file an issue to ask a question. You'll get faster results using the resources bellow:
 
-### Reporting bugs
+- [Github Discussions, the official Saga Icons message board](https://github.com/santosned/saga-icons/discussions)
 
-You can easily report bugs at [Github Issues](https://github.com/santosned/saga-icons/issues).
+#### Create new issues
 
-### Requesting features
+If you spot a problem within this project, [search if an issue already exists](https://github.com/santosned/saga-icons/issues?q=is%3Aissue+is%3Aopen). If a related issue doesn't exist, you can open a new issue using a relevant [issue template](https://github.com/santosned/saga-icons/issues/new/choose).
 
-This project welcomes your suggestions and new ideas, you are free to do so at [Github Issues](https://github.com/santosned/saga-icons/issues) or [Github Discussions](https://github.com/santosned/saga-icons/discussions).
+#### Solve an issue
 
-### Requesting icons
+Search through our [open issues](https://github.com/santosned/saga-icons/issues) to find one that interest you. Generally, no issue will be assign to anyone. If you find one, you are welcome to open a PR with a fix.
 
-While in early development, it's expected that the project will offer fewer icons than when in an stable release. Even though, you can still request for a specific icon at [Github Issues](https://github.com/santosned/saga-icons/issues).
+### Make changes
 
-This allows your **Icon Request** to be placed at [Github Projects](https://github.com/santosned/saga-icons/projects), which then can become part of the [Backlog](https://github.com/users/santosned/projects/1).
+#### Make changes locally
 
-## Development
+1. Fork the repository.
 
-### Dependencies
+- Using Github Desktop:
+  - [Getting started with Github Desktop](https://docs.github.com/en/desktop/installing-and-configuring-github-desktop/overview/getting-started-with-github-desktop) will guide you through setting up Desktop.
+  - Once Desktop is set up, you can use it to [fork the repo](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/cloning-and-forking-repositories-from-github-desktop)!
+- Using command line:
+  - [Fork the repo](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo#fork-an-example-repository) so that you can make your changes without affecting the original project until you're ready to merge them.
 
-Saga Icons uses [Node.js](https://nodejs.org/en/about/) to generate icons, so if you want to contribute to the source code, make sure to have installed the following:
+2. Install or update to **Node.js v18**. For more information, see the [Development Guide](docs/contributing/DEVELOPMENT.md).
+3. Create a working branch and start with your changes!
 
-- [Git](https://git-scm.com/downloads)
-- [Node latest LTS version](https://nodejs.org/en/download/)
+### Commit your update
 
-### Build system
+Once you are satisfied with the modifications, commit them. Remember to conduct a **self-evaluation** to facilitate the review process.
 
-<div align="center">
-  <img alt="Saga Icons Build system" src="docs/assets/build-system-diagram.webp">
-</div>
+### Pull Request
 
-The build system should be able to asynchronously generate multiple customizable [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) files from one simple [JSON schema](src/schemas/solid.json) file.
+When you're finished with the changes, create a pull request, also known as a PR.
 
-You are welcome to contribute to the improvement of this process by fixing bugs, improving performance, typos, documentation, or workflow.
+- Fill the "Ready for review" template so that we can review your PR. This template helps reviewers understand your changes as well as the purpose of your pull request.
+- If you are resolving an issue, remember to link the PR to it.
+- [Allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to be enabled so that the branch may be modified for a merging. After you submit your PR, the maintainer will examine it.
+- We may ask questions or request additional information.
+  We may ask for changes to be made before a PR can be merged, either using [suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request) or pull request comments. After you can make changes in your fork, then commit them to your branch.
+- As you update your PR and apply changes, mark each conversation as resolved.
+- If you run into any merge issues, checkout this [Git Tutorial](https://github.com/skills/resolve-merge-conflicts) to help you resolve merge conflicts and other issues.
 
-#### Release build
+### Your PR is merged!
 
-The build system also prepares the generated SVG files for the release files in Github by compressing them into a single zip file using the [adm-zip](https://github.com/cthackers/adm-zip) library.
+Congratulations 🎉 and thank you for the effort!
 
-### Testing
+Now you are part of the Saga Icons community ✨
 
-To avoid unexpected behaviors the [build system](#build-system) should be 100% tested to ensure consistency in each of the [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) files.
+[See how else you can contribute](docs/contributing/TYPES_OF_CONTRIBUTIONS.md).
 
-You can run tests by:
+## Styleguides
 
-- Clone and open this [repo](https://github.com/santosned/saga-icons.git)
-- Run `npm i` to install the dependencies.
-- Run `npm test` to test the code base.
+### Git Commit Messages
 
-Testing the main functionalities is extremely important, so keep in mind to add or update tests when needed.
+- Use the present tense ("Add" instead of "Added")
+- Avoid long first line messages, keep at 72 characters or less
+- Reference issues or pull requests after the first line
+- When only change documentation, include `[ci skip]` in the commit title. [See more about skipping workflows](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs)
 
-### Schemas
+### JavaScript code
 
-To add icons at the `src/schemas`, you should follow the format bellow:
+- Avoid platform-dependent code
+- Write clear and concise JSDoc for functions
+- Keep the names of objects, functions, or variables informative and brief so that no further documentation is required to understand them.
 
-```jsonc
-// src/schemas/solid.json
-{
-  "name": "solid", // The icons schema variant name
-  "icons": [
-    // Newest icons...
-    {
-      "keywords": ["mock", "empty", "example"], // List of words that describes the icon (e.g. ['searh', 'find'])
-      "drawn": "C 1.111 Z" // The d (drawn) attribute from the path element.
-    }
-    // Oldest icons...
-  ]
-}
-```
+### SVG icons
 
-The example above, using the build script, would generate something like (`icons/solid/web/mock-empty-example-24x24.svg`):
-
-```svg
-<svg viewBox="0 0 24 24" width="24" height="24"><g><path d="C 1.111 Z"/></g></svg>
-```
-
-The [d (drawn)](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d) attribute is the only thing from the designed [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) icons that are stored inside the [JSON schema](src/schemas/solid.json).
-
-This allows us to maintain a clean [schema](src/schemas/solid.json) file whilst easily customizing and generating hundreds of [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) files.
-
-### SVG designs
-
-If you're a designer, remember to setup your SVG editor (e.g. [inkscape](https://inkscape.org/)) to follow the specifications bellow:
-
-- SVG [viewBox="0 0 24 24"](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox) together with height and width of `24` pixels;
-- Max vector element [height](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/height) and [width](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/width) of `16` pixels;
-
-Before adding to the [schema file](src/schemas/solid.json) make sure that the follow are met:
-
-- Convert your vector to a single [path](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/path) element;
-- Make sure there's no additional styles (e.g. [strokes](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Fills_and_Strokes)) or [transform attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform).
-- Align vector to the center of the [viewBox](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox);
-
-A valid SVG would be something like this:
-
-```svg
-<svg viewBox="0 0 24 24" width="24" height="24" xmlns="http://www.w3.org/2000/svg">
-  <g>
-    <path d="M 10.712 4.471 C 11.456 3.843 12.544 3.843 13.287 4.471 L 19.278 9.525 C 19.728 9.904 19.988 10.462 19.988 11.051 L 19.988 18.447 C 19.988 19.305 19.293 20 18.434 20 L 15.772 20 C 14.914 20 14.218 19.305 14.218 18.447 L 14.218 14.735 C 14.218 14.368 13.92 14.069 13.553 14.069 L 10.446 14.069 C 10.079 14.069 9.781 14.368 9.781 14.735 L 9.781 18.447 C 9.781 19.305 9.086 20 8.228 20 L 5.565 20 C 4.708 20 4.012 19.305 4.012 18.447 L 4.012 11.051 C 4.012 10.462 4.271 9.904 4.721 9.525 L 10.712 4.471 Z" style=""/>
-  </g>
-</svg>
-```
-
-Next, copy the [d (drawn)](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d) attribute from the path element and paste it into the icon schema.
-
-Don't forget to add keywords to describe the icon 👌
-
-#### Adding to the repo
-
-After developing the [valid SVG icon](#svg-designs) and [adding it to the schema](#schemas), you can [commit](https://git-scm.com/docs/git-commit) your changes to the schema and open a [PR](https://github.com/santosned/saga-icons/pulls).
-
-⚠️ [PR's](https://github.com/santosned/saga-icons/pulls) to add new icons should add/change only one icon at time.
+Take a look in our [design guide](docs/contributing/DESIGN_OF_ICONS.md)

--- a/README.md
+++ b/README.md
@@ -4,29 +4,37 @@
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/santosned/saga-icons/nodejs-cli.yml?style=flat&colorA=black&colorB=black)
 ![GitHub issues](https://img.shields.io/github/issues/santosned/saga-icons?style=flat&colorA=black&colorB=black)
 
+> ⚠️ **Under early development!**
+
 A **open-source** collection of [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) icons for the web. Striving to build modern, clean and consistent icons following the [Scalable Vector Graphics (SVG) 2](https://www.w3.org/TR/SVG/) specifications.
 
-⚠️ **Under initial development!** take a look at the [Semantic Versioning](https://semver.org/) specifications for more information.
+## Production ready?
 
-## The repository
+Saga Icons does not anticipate releasing a production version until the following requirements have been met:
 
-This repository is where the `Saga Icons` project is developed. You can find and start [issues](https://github.com/santosned/saga-icons/issues), [discussions](https://github.com/santosned/saga-icons/discussions) and [contributions](https://github.com/santosned/saga-icons/pulls), which are available to anyone under the open-source [MIT license](LICENSE.txt).
+- The most often used web icons are included
+- And the build system is thoroughly tested
+
+You can still use the icons, but it's **not recommended on production** while in early development.
+
+## Downloading
+
+Get our **pre-release** zipped 📦 files via [Github Releases](https://github.com/santosned/saga-icons/releases)
 
 ## Contributing
 
-There are lots of ways in which you can contribute in this project, for example:
+See the [contributing guide](CONTRIBUTING.md) for detailed instructions on how to get started with our project.
 
-- [Reporting bugs, requesting features or icons](https://github.com/santosned/saga-icons/issues)
-- [Reviewing code changes](https://github.com/santosned/saga-icons/pulls)
-- [Reviewing documentations](/docs/) and [making pull requests](https://github.com/santosned/saga-icons/pulls) for typos or additional contents
+There are a few [types of contributions](docs/contributing/TYPES_OF_CONTRIBUTIONS.md) welcomed, some of which do not require you to write a single line of code.
 
-If you are interested in help fixing issues and contributing directly with the source code, please take a loook at [How To Contribute](CONTRIBUTING.md).
+If you want to contribute, you can go through our [existing issues](https://github.com/santosned/saga-icons/issues?q=is%3Aissue+is%3Aopen+) for something to work on. When you're ready, go to [Getting Started with Contributing](CONTRIBUTING.md#getting-started) for more information.
 
 ## Feedback
 
-- Ask questions at [Github Q&A](https://github.com/santosned/saga-icons/discussions/categories/q-a)
-- Request new features at [Github Issues](https://github.com/santosned/saga-icons/issues) or [Github Ideas](https://github.com/santosned/saga-icons/discussions/categories/ideas)
-- Upvote on [most requested features](https://github.com/santosned/saga-icons/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc)
+- 🙋 Ask questions at [Github Q&A](https://github.com/santosned/saga-icons/discussions/categories/q-a)
+- 💬 Request new features and icons at [Github Issues](https://github.com/santosned/saga-icons/issues) or [Github Ideas](https://github.com/santosned/saga-icons/discussions/categories/ideas)
+- 👍 Upvote on [most requested features](https://github.com/santosned/saga-icons/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc)
+- ⭐ Leave a star on the [repo](https://github.com/santosned/saga-icons)
 
 ## License
 

--- a/docs/contributing/DESIGN_OF_ICONS.md
+++ b/docs/contributing/DESIGN_OF_ICONS.md
@@ -1,0 +1,95 @@
+# Design of Icons
+
+Our icons follow a few conventions to make everything simplier and consistent.
+
+## Geometry
+
+### SVG
+
+Here are some resources that helps you understand how our [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) files are expected to be configured while designing icons.
+
+The basic styleguides our icons follow are listed bellow:
+
+- The path element should be aligned with the viewport's center.
+- The size (`width` or `height`) of the path element cannot be more than `16` pixels.
+- The path element can only have the [draw](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d) attribute and no other transformation or styles attributes, as showed in the [Draw Elements](#draw-elements) examples.
+
+#### Viewport
+
+> Note: The term "SVG viewport" differs from the term "viewport" used in CSS.
+
+The **viewport** is the region of the SVG that is visible. An SVG can logically be as wide and high as desired, but only a portion of the content can be visible at any given moment. The visible region is referred to as the **viewport**.
+
+You specify the size of the **viewport** using the `width` and `height` attributes of the SVG element. Here is an example:
+
+```svg
+<svg width="24" height="24"></svg>
+```
+
+This example defines a viewport with dimensions of `24` pixels wide by `24` pixels high. Which is our **default viewport**.
+
+#### Coordinate System Units
+
+The units you provide for the SVG element only impact its size (the viewport). The units you select for each shape define the size of the SVG shapes displayed in the SVG picture. If no units are supplied, pixels are used by default.
+
+Here is a list of the units that are available for SVG elements:
+
+| Units | Description                                                |
+| ----- | ---------------------------------------------------------- |
+| em    | The default font size - usually the height of a character. |
+| ex    | The height of the character x                              |
+| px    | Pixels (Default)                                           |
+| pt    | Points (1 / 72 of an inch)                                 |
+| pc    | Picas (1 / 6 of an inch)                                   |
+| cm    | Centimeters                                                |
+| mm    | Millimeters                                                |
+| in    | Inches                                                     |
+
+#### Viewbox
+
+Adding a **viewBox** property to a viewport element alters the [user coordinate system](https://www.w3.org/TR/SVG2/coords.html#InitialCoordinateSystem) relative to the viewport coordinate system, as explained in the [viewBox attribute](https://www.w3.org/TR/SVG2/coords.html#ViewBoxAttribute).
+
+```svg
+<svg viewBox="0 0 24 24" width="24" height="24"></svg>
+```
+
+The above example is our **default viewBox**.
+
+## Draw elements
+
+While drawing icons, you may use a variety of [SVG elements](https://developer.mozilla.org/en-US/docs/Web/SVG/Element); however, before appending it to the JSON schema, all elements must be combined into a single [path](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/path) element.
+
+For example, the [rect element](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/rect) bellow:
+
+```svg
+<svg viewBox="0 0 24 24" width="24" height="24">
+  <rect x="4" y="4" width="16" height="16"/>
+</svg>
+```
+
+It should be converted into a single path.
+
+```svg
+<svg viewBox="0 0 24 24" width="24" height="24">
+  <path d="M 4 4 H 20 V 20 H 4 V 4 Z"/>
+</svg>
+```
+
+The same goes if you have multiple elements:
+
+```svg
+<svg viewBox="0 0 24 24" width="24px" height="24px">
+  <rect x="4.01" y="4.01" width="8" height="8"/>
+  <rect x="11.99" y="11.99" width="8" height="8"/>
+</svg>
+```
+
+They all should be combined into one path:
+
+```svg
+<svg viewBox="0 0 24 24" width="24" height="24">
+  <path d="M 4.01 4.01 L 12.01 4.01 L 12.01 11.99 L 19.99 11.99 L 19.99 19.99 L 11.99 19.99 L 11.99 12.01 L 4.01 12.01 Z"/>
+</svg>
+```
+
+Fortunately, the most common SVG editors can accomplish this for you automatically 😋 ✨

--- a/docs/contributing/DEVELOPMENT.md
+++ b/docs/contributing/DEVELOPMENT.md
@@ -1,0 +1,33 @@
+# Development
+
+This document describes the process for running this application on your local computer.
+
+## Getting started
+
+Saga Icons is powered by Node.js! ✨ 📦 🚀
+
+It runs on macOS, Windows, and Linux environments.
+
+You'll need Node.js version 18 to run our code base. To install Node.js, [download the "LTS" installer from nodejs.org](https://nodejs.org/en/download/). If you're using [`nodenv`](https://github.com/nodenv/nodenv), read the [`nodenv` docs](https://github.com/nodenv/nodenv#readme) for instructions on switching Node.js versions.
+
+Once you've installed Node.js (which includes the popular `npm` package manager), open Terminal and run the following:
+
+```sh
+git clone https://github.com/santosned/saga-icons
+cd saga-icons
+npm ci
+npm run build
+```
+
+You should now have access to the `icons/` folder containing our latest icons.
+
+Note that `npm ci` and `npm run build` are steps that should only be executed once every time you pull the latest for a branch.
+
+- `npm ci` does a clean install of dependencies, without updating the `package-lock.json` file
+- `npm run build` creates static assets, such as SVG and text files.
+
+## Other Resources
+
+For more info about working with this site, check out:
+
+- [tests/README.md](../tests/README.md)

--- a/docs/contributing/TYPES_OF_CONTRIBUTIONS.md
+++ b/docs/contributing/TYPES_OF_CONTRIBUTIONS.md
@@ -1,0 +1,35 @@
+# Types of Contributions
+
+You can contribute to the Saga Icons in several ways.
+
+### 📣 Discussions
+
+[Discussions](https://github.com/santosned/saga-icons/discussions) is the place to have conversations. If you'd like help troubleshooting a PR you're working on, have a great new idea, or want to share some icon sketch, join us there.
+
+### 🐛 Issues
+
+[Issues](https://docs.github.com/en/github/managing-your-work-on-github/about-issues) are used to track tasks that contributors can help with. If you've found something in the main branch that should be updated, search open issues to see if someone else has reported the same thing.
+
+If it's something new, open an issue using a [template](https://github.com/santosned/saga-icons/issues/new/choose). We'll use the issue to have a conversation about the problem you want to fix.
+
+### 🔧 Pull requests
+
+A [pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) is a way to suggest changes in our repository.
+
+If you want to add one or more icons into the project, please [fill a issue](https://github.com/santosned/saga-icons/issues/new/choose) before open a pull requests.
+
+### 📞 Support
+
+Unfortunately, we just can't help with support questions in this repository. If you have issues with something like how to style SVG icons, how to setup Node.js or Git, please search for it on [Google](https://www.google.com/), [Stack Overflow](https://stackoverflow.com/), or the related project's documentation like [Github Docs](https://docs.github.com/).
+
+### 🌎 Translations
+
+The source content in this repository is written in **English**. It's expected that translating this project to other languages becomes a topic in the future, but there's no plan while in **early development**.
+
+### ⚖️ Policy
+
+See [the CONTRIBUTING guide](../../CONTRIBUTING.md).
+
+## Attribution
+
+This document is adapted from [Types of Contributions](https://github.com/github/docs/blob/main/contributing/types-of-contributions.md) on [Github Docs](https://github.com/github/docs).

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -1,0 +1,42 @@
+## Tests
+
+Running tests locally while developing is not strictly necessary. You can always start a pull request and let the CI service run tests for you, but it's a good idea to run tests locally first before sending your changes to GitHub.
+
+Tests are written using [jest](https://jestjs.io/docs/getting-started), a framework maintained by Facebook and used by many teams at GitHub.
+
+Jest provides everything: a test runner, an assertion library, code coverage analysis, custom reporters for different types of test output, etc.
+
+### Install optional dependencies
+
+We typically rely on CI to run our tests. To run the tests locally, you'll
+need to make sure optional dependencies are installed by running:
+
+```sh
+npm ci --include=optional
+```
+
+### Running all the tests
+
+Once you've followed the development instructions above, you can run the entire
+test suite locally:
+
+```sh
+npm test
+```
+
+### Linting
+
+To validate all your JavaScript code (and auto-format some easily reparable mistakes),
+run the linter:
+
+```sh
+npm run lint
+```
+
+### Formatting
+
+To make sure all our code are formatted properly run the formatter:
+
+```sh
+npm run format
+```


### PR DESCRIPTION
Instead of adding the development environment setup guide in the README.md, as I mentioned in the #9 issue, I created a DEVELOPMENT.md that handles resources about development.


Closes #9 